### PR TITLE
Add unit tests for HTML classes

### DIFF
--- a/src/test/java/HtmlReaderTest.java
+++ b/src/test/java/HtmlReaderTest.java
@@ -1,0 +1,24 @@
+import org.junit.jupiter.api.Test;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HtmlReaderTest {
+    @Test
+    void testReadHtmlString() {
+        String html = "<div id=\"main\"><span>text</span></div><img src=\"x\" />";
+        List<HtmlTag> tags = HtmlReader.read(html);
+        assertEquals(2, tags.size());
+
+        HtmlTag div = tags.get(0);
+        assertEquals("div", div.tagName());
+        assertEquals("main", div.getAttribute("id"));
+        assertEquals(1, div.children().size());
+        assertEquals("span", div.children().get(0).tagName());
+        assertEquals("text", div.children().get(0).content());
+
+        HtmlTag img = tags.get(1);
+        assertEquals("img", img.tagName());
+        assertTrue(img.selfClosing());
+        assertEquals("x", img.getAttribute("src"));
+    }
+}

--- a/src/test/java/HtmlTagBuilderTest.java
+++ b/src/test/java/HtmlTagBuilderTest.java
@@ -1,0 +1,20 @@
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HtmlTagBuilderTest {
+    @Test
+    void testBuilderCreatesTag() {
+        HtmlTag child = new HtmlTagBuilder("span").content("child").build();
+        HtmlTag tag = new HtmlTagBuilder("div")
+                .addAttribute("id", "main")
+                .addChild(child)
+                .content("text")
+                .build();
+
+        assertEquals("div", tag.tagName());
+        assertEquals("text", tag.content());
+        assertEquals("main", tag.getAttribute("id"));
+        assertEquals(1, tag.children().size());
+        assertEquals("span", tag.children().get(0).tagName());
+    }
+}

--- a/src/test/java/HtmlTagTest.java
+++ b/src/test/java/HtmlTagTest.java
@@ -1,0 +1,43 @@
+import org.junit.jupiter.api.Test;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HtmlTagTest {
+    @Test
+    void testAttributeAccessAndWithAttribute() {
+        HashMap<String, String> attrs = new HashMap<>();
+        attrs.put("int", "5");
+        attrs.put("double", "3.14");
+        attrs.put("bool", "true");
+        HtmlTag tag = HtmlTag.of("div", "", attrs);
+
+        assertEquals("5", tag.getAttribute("int"));
+        assertEquals(5, tag.getAttributeAsInt("int"));
+        assertEquals(3.14, tag.getAttributeAsDouble("double"));
+        assertTrue(tag.getAttributeAsBoolean("bool"));
+
+        assertEquals("", tag.getAttribute("missing"));
+        assertEquals(0, tag.getAttributeAsInt("missing"));
+        assertEquals(0.0, tag.getAttributeAsDouble("missing"));
+        assertFalse(tag.getAttributeAsBoolean("missing"));
+
+        HtmlTag modified = tag.withAttribute("extra", "value");
+        assertEquals("value", modified.getAttribute("extra"));
+        assertTrue(modified.hasAttribute("extra"));
+    }
+
+    @Test
+    void testMutationHelpersAndFactories() {
+        HtmlTag base = HtmlTag.empty("p");
+        HtmlTag withContent = base.withContent("hello");
+        assertEquals("hello", withContent.content());
+
+        HtmlTag withChild = base.withChildren(List.of(HtmlTag.of("span", "t")));
+        assertTrue(withChild.hasChildren());
+
+        HtmlTag selfClosing = HtmlTag.selfClosing("br");
+        assertTrue(selfClosing.selfClosing());
+    }
+}

--- a/src/test/java/HtmlWriterTest.java
+++ b/src/test/java/HtmlWriterTest.java
@@ -1,0 +1,27 @@
+import org.junit.jupiter.api.Test;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HtmlWriterTest {
+    @Test
+    void testWriteSimpleTag() throws Exception {
+        HtmlTag br = new HtmlTagBuilder("br").selfClosing(true).build();
+        HtmlTag tag = new HtmlTagBuilder("div")
+                .addAttribute("class", "container")
+                .addChild(br)
+                .content("Hello")
+                .build();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        HtmlWriter writer = new HtmlWriter(out, "  ");
+        writer.write(tag);
+
+        String expected = "<div class=\"container\">\n" +
+                "  Hello\n" +
+                "  <br />\n" +
+                "</div>\n";
+        String result = out.toString(StandardCharsets.UTF_8);
+        assertEquals(expected, result);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for HtmlTag utilities
- cover HtmlTagBuilder behavior
- verify HtmlWriter output
- test parsing with HtmlReader

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_688929c0a9f88321a4b4a6b9bf777922